### PR TITLE
Enable ImageMagick support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Specfile consists out of the main package <code>fdk-aac-dabplus-odr</code> a
 
 The package supports [conditional builds](http://www.rpm.org/wiki/PackagerDocs/ConditionalBuilds) with the following default parameters (see the [FDK-AAC-DABplus package description](https://github.com/Opendigitalradio/fdk-aac-dabplus/blob/master/README.md) for further information):
 ```bash
- rpmbuild -ba fdk-aac-dabplus-odr.spec --with alsa --without imagemagick --without jack --without vlc
+ rpmbuild -ba fdk-aac-dabplus-odr.spec --with alsa --with imagemagick --without jack --without vlc
 ```
 
 ## Usage

--- a/fdk-aac-dabplus-odr.spec
+++ b/fdk-aac-dabplus-odr.spec
@@ -45,8 +45,8 @@
 # Conditional build support
 # add --without alsa option, i.e. enable alsa by default
 %bcond_without alsa
-# add --without imagemagick option, i.e. disable imagemagick by default
-%bcond_with imagemagick
+# add --without imagemagick option, i.e. enable imagemagick by default
+%bcond_without imagemagick
 # add --with jack option, i.e. disable jack by default
 %bcond_with jack
 # add --with vlc option, i.e. disable vlc by default


### PR DESCRIPTION
Make sending MOT slideshows way easier because images that are out of bounds can get converted automatically.

Fixes #2 and seems to be the default way to run this for now.
